### PR TITLE
change from ASCII to UTF-8 encoding

### DIFF
--- a/lp-election-helper
+++ b/lp-election-helper
@@ -98,7 +98,7 @@ def main():
     print "#### Members with no public email address or GPG key ####"
     print
     for missed_account in missed_accounts:
-        print missed_account
+        print missed_account.encode('utf-8')
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
For the accounts that have no public email address or GPG key (`missed_account`), a list is printed consisting of the Display Name (usually the person's name) and the username (i.e. their Launchpad account). If either includes Unicode, printing fails with `UnicodeEncodeError: 'ascii' codec can't encode character u'\<the character>' in position <location in the string>: ordinal not in range (128)` due to the fact that the default encoding is ASCII rather than UTF-8. This little change will keep that from blowing up and allow for a more complete list of missing accounts.